### PR TITLE
Fixes for non-cocoapods when leanplum kit should reference framework

### DIFF
--- a/mParticle-Leanplum/MPKitLeanplum.m
+++ b/mParticle-Leanplum/MPKitLeanplum.m
@@ -24,6 +24,10 @@
 #import "Leanplum.h"
 #endif
 
+// Since MPIConstants.h isn't exposed via the mParticle framework
+static NSString * const kMPUserIdentityTypeKey = @"n";
+static NSString * const kMPUserIdentityIdKey = @"i";
+
 @implementation MPKitLeanplum
 
 + (NSNumber *)kitCode {
@@ -81,8 +85,8 @@
 
         NSString *userId = nil;
         for (NSDictionary<NSString *, id> *userIdentity in self.userIdentities) {
-            MPUserIdentity identityType = (MPUserIdentity)[userIdentity[@"n"] integerValue];
-            NSString *identityString = userIdentity[@"i"];
+            MPUserIdentity identityType = (MPUserIdentity)[userIdentity[kMPUserIdentityTypeKey] integerValue];
+            NSString *identityString = userIdentity[kMPUserIdentityIdKey];
 
             if (identityType == [self preferredIdentityType]) {
                 userId = identityString;

--- a/mParticle-Leanplum/MPKitLeanplum.m
+++ b/mParticle-Leanplum/MPKitLeanplum.m
@@ -17,12 +17,12 @@
 //
 
 #import "MPKitLeanplum.h"
-#import "mParticle.h"
-#import "MPKitRegister.h"
-#import "MPEnums.h"
-#import "MPIConstants.h"
 
+#if defined(__has_include) && __has_include(<Leanplum/Leanplum.h>)
+#import <Leanplum/Leanplum.h>
+#else
 #import "Leanplum.h"
+#endif
 
 @implementation MPKitLeanplum
 
@@ -81,8 +81,8 @@
 
         NSString *userId = nil;
         for (NSDictionary<NSString *, id> *userIdentity in self.userIdentities) {
-            MPUserIdentity identityType = (MPUserIdentity)[userIdentity[kMPUserIdentityTypeKey] integerValue];
-            NSString *identityString = userIdentity[kMPUserIdentityIdKey];
+            MPUserIdentity identityType = (MPUserIdentity)[userIdentity[@"n"] integerValue];
+            NSString *identityString = userIdentity[@"i"];
 
             if (identityType == [self preferredIdentityType]) {
                 userId = identityString;


### PR DESCRIPTION
When mParticle and Leanplum are integrated as a frameworks the leanplum kit needs to reference the header files in the framework as `<Leanplum/Leanplum.h>` so I made the imports conditional. I also removed some unnecessary imports.

The leanplum kit doesn't have access to MPIConstants.h because the mParticle framework doesn't expose it so I had to replace the 2 constant references with strings (which I'm not crazy about but didn't see any other solution). Let me know if there's a better way to handle that.
