### PR TITLE
Device ID setting

### DIFF
--- a/mParticle-Leanplum/MPKitLeanplum.m
+++ b/mParticle-Leanplum/MPKitLeanplum.m
@@ -110,13 +110,9 @@ static NSString * const kMPLeanplumEmailUserAttributeKey = @"email";
             deviceIdType = @"";
         }
         if ([deviceIdType isEqualToString:@"idfa"]) {
-            LEANPLUM_USE_ADVERTISING_ID
-        } else if ([deviceIdType isEqualToString:@"idfv"]) {
-            [Leanplum setDeviceId:[[[UIDevice currentDevice] identifierForVendor] UUIDString]];
+            LEANPLUM_USE_ADVERTISING_ID;
         } else if ([deviceIdType isEqualToString:@"das"]) {
             [Leanplum setDeviceId:[MParticle sharedInstance].identity.deviceApplicationStamp];
-        } else if ([deviceIdType isEqualToString:@"leanplumDefault"]) {
-            //do nothing
         }
         
         FilteredMParticleUser *user = [self currentUser];

--- a/mParticle-Leanplum/MPKitLeanplum.m
+++ b/mParticle-Leanplum/MPKitLeanplum.m
@@ -105,6 +105,20 @@ static NSString * const kMPLeanplumEmailUserAttributeKey = @"email";
             [Leanplum setAppId:self.configuration[@"appId"] withProductionKey:self.configuration[@"clientKey"]];
         }
         
+        NSString *deviceIdType = self.configuration[@"iosDeviceId"];
+        if (deviceIdType == nil) {
+            deviceIdType = @"";
+        }
+        if ([deviceIdType isEqualToString:@"idfa"]) {
+            LEANPLUM_USE_ADVERTISING_ID
+        } else if ([deviceIdType isEqualToString:@"idfv"]) {
+            [Leanplum setDeviceId:[[[UIDevice currentDevice] identifierForVendor] UUIDString]];
+        } else if ([deviceIdType isEqualToString:@"das"]) {
+            [Leanplum setDeviceId:[MParticle sharedInstance].identity.deviceApplicationStamp];
+        } else if ([deviceIdType isEqualToString:@"leanplumDefault"]) {
+            //do nothing
+        }
+        
         FilteredMParticleUser *user = [self currentUser];
         NSString *userId = [self generateUserId:self.configuration
                                            user:user];


### PR DESCRIPTION
## Summary
This change is to allow kit users to choose which iOS ID to send with the ios configuraiton DeviceId setting. The Leanplum SDK automatically handles this for the default ID of IDFV. https://docs.leanplum.com/docs/which-device-id-format-should-i-use

## Testing Plan
Ran test app with integration

## Master Issue
Closes mParticle/issues/issues/4685
