### PR TITLE
Forward push token to Leanplum

### DIFF
--- a/mParticle-Leanplum/MPKitLeanplum.m
+++ b/mParticle-Leanplum/MPKitLeanplum.m
@@ -286,6 +286,15 @@ static NSString * const kMPLeanplumEmailUserAttributeKey = @"email";
     return execStatus;
 }
 
+- (MPKitExecStatus *)setDeviceToken:(NSData *)deviceToken {
+#if TARGET_OS_IOS == 1
+    [Leanplum didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+#endif
+
+    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeSuccess];
+    return execStatus;
+}
+
 #pragma mark Events
 
 - (nonnull MPKitExecStatus *)logBaseEvent:(nonnull MPBaseEvent *)event {

--- a/mParticle-Leanplum/MPKitLeanplum.m
+++ b/mParticle-Leanplum/MPKitLeanplum.m
@@ -291,7 +291,7 @@ static NSString * const kMPLeanplumEmailUserAttributeKey = @"email";
     [Leanplum didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 #endif
 
-    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppboy) returnCode:MPKitReturnCodeSuccess];
+    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceLeanplum) returnCode:MPKitReturnCodeSuccess];
     return execStatus;
 }
 


### PR DESCRIPTION
By default, Leanplum's iOS SDK uses method swizzling to collect push tokens. However when this is disabled(https://docs.leanplum.com/changelog/custom-push-notification-swizzling-for-ios) - you need to call Leanplums methods manually to collect the push token. Currently the mParticle SDK does not forward push tokens to Leanplum. This PR addresses that. 

Per Leanplums docs(https://docs.leanplum.com/changelog/custom-push-notification-swizzling-for-ios) - calling leanplums methods manually when swizzling is enabled does not affect the SDK . So regardless of whether swizzling is enabled or disabled the mParticle<> Leanplum Kit should be able to manually pass the push token to Leanplum.

<img width="919" alt="Screen Shot 2021-08-13 at 12 49 34 PM" src="https://user-images.githubusercontent.com/19657993/129393087-93983b25-bc00-4649-bc20-871024c1a900.png">
