### PR TITLE
Add SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
                .upToNextMajor(from: "8.7.0")),
       .package(name: "Leanplum",
                url: "https://github.com/leanplum/leanplum-ios-sdk",
-               .upToNextMajor(from: "4.1.0")),
+               .upToNextMajor(from: "3.1.0")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "mParticle-Leanplum",
+    platforms: [ .iOS(.v9) ],
+    products: [
+        .library(
+            name: "mParticle-Leanplum",
+            targets: ["mParticle-Leanplum"]),
+    ],
+    dependencies: [
+      .package(name: "mParticle-Apple-SDK",
+               url: "https://github.com/mParticle/mparticle-apple-sdk",
+               .upToNextMajor(from: "8.7.0")),
+      .package(name: "Leanplum",
+               url: "https://github.com/leanplum/leanplum-ios-sdk",
+               .upToNextMajor(from: "4.1.0")),
+    ],
+    targets: [
+        .target(
+            name: "mParticle-Leanplum",
+            dependencies: ["mParticle-Apple-SDK","Leanplum"],
+            path: "mParticle-Leanplum",
+            publicHeadersPath: "."),
+    ]
+)


### PR DESCRIPTION
# Summary

Adds SPM support to the Leanplum integration using roughly the same definitions as defined in `Cartfile`.  

**NOTE**: In our host app repository, I found we needed to pin `Leanplum` to `3.1.0` as `3.2.0` had problems compiling (due to code unrelated to this integration). I don't think these problems were present in this integration, so `.upToNextMajor(from: "3.1.0"))` should be fine.
