### PR TITLE
feat: Improve Privacy Manifest support for iOS 17

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
-github "leanplum/leanplum-ios-sdk" ~> 6.1
-github "mparticle/mparticle-apple-sdk" ~> 8.0
+github "CleverTap/clevertap-ios-sdk" ~> 6.2
+github "leanplum/leanplum-ios-sdk" ~> 6.4
+github "mparticle/mparticle-apple-sdk" ~> 8.22

--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,10 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.7.0")),
+               .upToNextMajor(from: "8.22.0")),
       .package(name: "Leanplum",
                url: "https://github.com/leanplum/leanplum-ios-sdk",
-               .upToNextMajor(from: "6.1.0")),
+               .upToNextMajor(from: "6.4.2")),
     ],
     targets: [
         .target(
@@ -23,6 +23,7 @@ let package = Package(
             dependencies: ["mParticle-Apple-SDK","Leanplum"],
             path: "mParticle-Leanplum",
             exclude: ["File.swift", "Info.plist"],
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: ".",
             cSettings: [
                 .headerSearchPath("."),

--- a/mParticle-Leanplum.podspec
+++ b/mParticle-Leanplum.podspec
@@ -15,12 +15,7 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Leanplum/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'Leanplum-iOS-SDK', '~> 6.1'
-    s.ios.frameworks = 'CFNetwork', 'SystemConfiguration', 'Security', 'CoreLocation', 'StoreKit'
-    s.ios.weak_frameworks = 'AdSupport'
-    s.ios.pod_target_xcconfig = {
-        'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Leanplum-iOS-SDK/**',
-        'OTHER_LDFLAGS' => '$(inherited) -framework "Leanplum"'
-    }
+    s.ios.resource_bundles  = { 'mParticle-Leanplum-Privacy' => ['mParticle-Leanplum/PrivacyInfo.xcprivacy'] }
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
+    s.ios.dependency 'Leanplum-iOS-SDK', '~> 6.4'
 end

--- a/mParticle-Leanplum.xcodeproj/project.pbxproj
+++ b/mParticle-Leanplum.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -17,8 +17,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		535B24AB285798AF003141C8 /* Leanplum.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Leanplum.xcframework; path = Carthage/Build/Leanplum.xcframework; sourceTree = "<group>"; };
-		535B24AD285798B5003141C8 /* mParticle_Apple_SDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = mParticle_Apple_SDK.xcframework; path = Carthage/Build/mParticle_Apple_SDK.xcframework; sourceTree = "<group>"; };
+		535B24AB285798AF003141C8 /* Leanplum.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:4XLWYATZ5P:Leanplum, Inc."; lastKnownFileType = wrapper.xcframework; name = Leanplum.xcframework; path = Carthage/Build/Leanplum.xcframework; sourceTree = "<group>"; };
+		535B24AD285798B5003141C8 /* mParticle_Apple_SDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:DLD43Y3TRP:mParticle, inc"; lastKnownFileType = wrapper.xcframework; name = mParticle_Apple_SDK.xcframework; path = Carthage/Build/mParticle_Apple_SDK.xcframework; sourceTree = "<group>"; };
 		537FB0DF284AB1BF0097D765 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		53E9ACCA2BBF0E540062A03A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		DB7E05A41CB819D300967FDF /* MPKitLeanplum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitLeanplum.h; sourceTree = "<group>"; };

--- a/mParticle-Leanplum/PrivacyInfo.xcprivacy
+++ b/mParticle-Leanplum/PrivacyInfo.xcprivacy
@@ -7,12 +7,8 @@
     <key>NSPrivacyTrackingDomains</key>
     <array/>
     <key>NSPrivacyCollectedDataTypes</key>
-    <array>
-        <dict/>
-    </array>
+    <array/>
     <key>NSPrivacyAccessedAPITypes</key>
-    <array>
-        <dict/>
-    </array>
+    <array/>
 </dict>
 </plist>


### PR DESCRIPTION
 ## Summary
 - Fix parsing issue due to empty dict
 - Ensure manifest is included by package managers

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed in test apps

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6413